### PR TITLE
feat: Add support for Heidelberg Connect series

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This integration allows you to monitor and control your **Heidelberg Energy Cont
 ## Overview
 The Heidelberg Energy Control wallbox supports the Modbus RTU protocol for external control. Since Home Assistant communicates over your network, a **Modbus TCP to RTU gateway** (like a PE11 or similar) is typically required to bridge the connection unless your wallbox is equipped with a native network interface.
 
+### Heidelberg Connect Series
+This integration also supports the **Heidelberg Connect series** (heidelberg.home and heidelberg.solar). These wallboxes feature a native network interface and support Modbus TCP directly, eliminating the need for an external gateway.
+
+**Note:** Support for the Connect series is currently in **beta stage**.
+
+If you encounter any problems or have suggestions for improvements, please report them on our [Issues page](https://github.com/Schrolli91/heidelberg_energy_control/issues).
+
 Fully compatible with the evcc home assitant charger.
 
 ## Installation via HACS

--- a/custom_components/heidelberg_energy_control/manifest.json
+++ b/custom_components/heidelberg_energy_control/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pymodbus>=3.11.2"
   ],
-  "version": "1.0.2-b3"
+  "version": "1.1.0-rc1"
 }

--- a/custom_components/heidelberg_energy_control/manifest.json
+++ b/custom_components/heidelberg_energy_control/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pymodbus>=3.11.2"
   ],
-  "version": "1.1.0-rc1"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Description
This adds support for the Heidelberg Connect series wallboxes (connect.home and connect.solar) which feature a native network interface and support Modbus TCP directly, eliminating the need for an external gateway. The support is currently in beta stage.

### Checklist
- [x] The PR title follows the format: `type: description` (feat, fix, perf, docs, chore, ci)
- [x] I have tested these changes in my Home Assistant environment
- [x] I have linked a related Issue if one exists

**Issue:** closes #16 