### PR TITLE
feat: Set standby mode (reg 258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This integration provides a comprehensive set of entities to monitor and control
 
 #### 🎮 Controls
 * **Charge Enable**: Toggle to start or stop the charging process.
+* **Standby Mode**: Enable or disable the wallbox power-saving standby function.
 * **Charging Current Limit**: Adjust the maximum allowed charging current (6A - 16A).
 * **Remote Lock**: Disable and lock the charging process to prevent unauthorized use.
 

--- a/custom_components/heidelberg_energy_control/const.py
+++ b/custom_components/heidelberg_energy_control/const.py
@@ -48,6 +48,8 @@ DATA_SESSION_ENERGY = "session_energy"
 DATA_IS_PLUGGED = "is_plugged"
 DATA_IS_CHARGING = "is_charging"
 # Hardware Command
+COMMAND_STANDBY = "standby_function_control"
+REG_COMMAND_STANDBY = 258
 COMMAND_REMOTE_LOCK = "remote_lock_command"
 REG_COMMAND_REMOTE_LOCK = 259
 COMMAND_TARGET_CURRENT = "max_current_command"

--- a/custom_components/heidelberg_energy_control/core/api.py
+++ b/custom_components/heidelberg_energy_control/core/api.py
@@ -13,6 +13,7 @@ from ..const import (
     CHARGING_STATE_MAP,
     COMMAND_REMOTE_LOCK,
     COMMAND_TARGET_CURRENT,
+    COMMAND_STANDBY,
     DATA_CHARGING_POWER,
     DATA_CHARGING_STATE,
     DATA_CURRENT,
@@ -40,6 +41,7 @@ from ..const import (
     REG_HW_VERS,
     REG_SW_VERS,
     REG_LAYOUT,
+    REG_COMMAND_STANDBY,
     REG_COMMAND_REMOTE_LOCK,
     REG_COMMAND_TARGET_CURRENT,
 )
@@ -201,12 +203,22 @@ class HeidelbergEnergyControlAPI:
                 raise HeidelbergEnergyControlReadError(
                     "Failed to read remote lock register"
                 )
+            standby = await self._client.read_holding_registers(
+                address=REG_COMMAND_STANDBY,
+                count=1,
+                device_id=self._device_id,
+            )
+            if standby.isError():
+                raise HeidelbergEnergyControlReadError(
+                    "Failed to read standby register"
+                )
 
             cmd_duration = time.perf_counter() - cmd_start
 
             data_regs = data.registers
             remote_lock_regs = remote_lock.registers
             target_current_regs = target_current.registers
+            standby_regs = standby.registers
 
             if not data_regs or len(data_regs) < REG_DATA_COUNT:
                 _LOGGER.error(
@@ -258,6 +270,7 @@ class HeidelbergEnergyControlAPI:
                 # COMMAND
                 COMMAND_REMOTE_LOCK: remote_lock_regs[0] == 0,  # 0 = Locked / 1 = Unlocked
                 COMMAND_TARGET_CURRENT: target_current_regs[0] / 10.0,
+                COMMAND_STANDBY: standby_regs[0] == 0,  # 0 = enabled / 4 = disabled
             }
 
         except (ModbusException, OSError, IndexError) as err:

--- a/custom_components/heidelberg_energy_control/switch.py
+++ b/custom_components/heidelberg_energy_control/switch.py
@@ -13,7 +13,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HeidelbergEnergyControlConfigEntry
 from .classes.heidelberg_switch import HeidelbergSwitch
 from .classes.heidelberg_switch_virtual import HeidelbergSwitchVirtual
-from .const import COMMAND_REMOTE_LOCK, REG_COMMAND_REMOTE_LOCK, VIRTUAL_ENABLE
+from .const import (
+    COMMAND_REMOTE_LOCK,
+    COMMAND_STANDBY,
+    REG_COMMAND_REMOTE_LOCK,
+    REG_COMMAND_STANDBY,
+    VIRTUAL_ENABLE,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -38,6 +44,16 @@ SWITCH_TYPES: tuple[HeidelbergSwitchEntityDescription, ...] = (
         on_value=0,
         off_value=1,
         min_version="1.0.4"
+    ),
+    HeidelbergSwitchEntityDescription(
+        key=COMMAND_STANDBY,
+        translation_key=COMMAND_STANDBY,
+        icon="mdi:sleep",
+        entity_category=EntityCategory.CONFIG,
+        register=REG_COMMAND_STANDBY,
+        on_value=0,
+        off_value=4,
+        min_version="1.0.8"
     ),
     HeidelbergSwitchEntityDescription(
         key=VIRTUAL_ENABLE,

--- a/custom_components/heidelberg_energy_control/translations/de.json
+++ b/custom_components/heidelberg_energy_control/translations/de.json
@@ -121,6 +121,9 @@
       }
     },
     "switch": {
+      "standby_function_control": {
+        "name": "Standby-Modus"
+      },
       "remote_lock_command": {
         "name": "Remote Lock"
       },

--- a/custom_components/heidelberg_energy_control/translations/en.json
+++ b/custom_components/heidelberg_energy_control/translations/en.json
@@ -121,6 +121,9 @@
       }
     },
     "switch": {
+      "standby_function_control": {
+        "name": "Standby mode"
+      },
       "remote_lock_command": {
         "name": "Remote Lock"
       },


### PR DESCRIPTION
Add a switch to control the standby mode of the wallbox. Disabling standby mode allows the wallbox to always stay connected to Home Assistant instead of going into standby after 10 minutes with no car plugged in.

## Description
- Added a switch entity to control the standby mode.
- Uses Modbus register 258.
- Standby mode is enabled by default (value `0`) and can be disabled (value `4`).
