### PR TITLE
feat: add standby-mode switch (register 258, v1.0.8+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This integration provides a comprehensive set of entities to monitor and control
 * **Charge Enable**: Toggle to start or stop the charging process.
 * **Charging Current Limit**: Adjust the maximum allowed charging current (6A - 16A).
 * **Remote Lock**: Disable and lock the charging process to prevent unauthorized use.
+* **Standby Mode**: Enable or disable the wallbox power-saving standby function (requires firmware ≥ 1.0.8).
 
 #### 📊 Monitoring (Sensors)
 * **Charging Power**: Real-time power consumption in Watts.

--- a/custom_components/heidelberg_energy_control/const.py
+++ b/custom_components/heidelberg_energy_control/const.py
@@ -49,6 +49,7 @@ DATA_IS_PLUGGED = "is_plugged"
 DATA_IS_CHARGING = "is_charging"
 # Hardware Command
 COMMAND_REMOTE_LOCK = "remote_lock_command"
+COMMAND_STANDBY = "standby_function_control"
 COMMAND_TARGET_CURRENT = "max_current_command"
 # Virtual
 VIRTUAL_ENABLE = "virtual_enable"

--- a/custom_components/heidelberg_energy_control/core/capabilities/__init__.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from .base import Capability
 from .core import CoreCapability
+from .standby import StandbyCapability
 
-CAPABILITIES: tuple[type[Capability], ...] = (CoreCapability,)
+CAPABILITIES: tuple[type[Capability], ...] = (CoreCapability, StandbyCapability)
 
-__all__ = ["CAPABILITIES", "Capability", "CoreCapability"]
+__all__ = ["CAPABILITIES", "Capability", "CoreCapability", "StandbyCapability"]

--- a/custom_components/heidelberg_energy_control/core/capabilities/standby.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/standby.py
@@ -1,0 +1,72 @@
+"""Standby-mode capability (v1.0.8+).
+
+Owns holding register 258 (standby function control): value 0 enables
+the wallbox's built-in standby (default), value 4 disables it so the
+device stays awake and remains reachable over Modbus indefinitely.
+
+Landed with layout version 1.0.8, so the whole Amperfied connect-series
+line supports it, but Heidelberg Energy Control units on firmware
+below 1.0.8 do not.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pymodbus.exceptions import ModbusException
+
+from ...const import COMMAND_STANDBY
+from ..exceptions import HeidelbergEnergyControlWriteError
+from ..registers import RegisterDefinition, RegisterType
+from .base import Capability
+
+_LOGGER = logging.getLogger(__name__)
+
+REG_COMMAND_STANDBY = 258
+
+_STANDBY_ENABLED = 0
+_STANDBY_DISABLED = 4
+
+_COMMAND_REGISTERS: dict[str, int] = {
+    COMMAND_STANDBY: REG_COMMAND_STANDBY,
+}
+
+
+class StandbyCapability(Capability):
+    """Standby-mode control (holding register 258)."""
+
+    key = "standby"
+    min_layout_version = "1.0.8"
+
+    polled_definitions: tuple[RegisterDefinition, ...] = (
+        RegisterDefinition(REG_COMMAND_STANDBY, 1, RegisterType.HOLDING),
+    )
+
+    def decode_polled(self, registers: dict[int, int]) -> dict[str, Any]:
+        # Switch is "on" when the standby function is enabled (register = 0).
+        return {COMMAND_STANDBY: registers[REG_COMMAND_STANDBY] == _STANDBY_ENABLED}
+
+    def supports_write(self, key: str) -> bool:
+        return key in _COMMAND_REGISTERS
+
+    async def async_write(
+        self, client: Any, device_id: int, key: str, value: int
+    ) -> bool:
+        address = _COMMAND_REGISTERS[key]
+        try:
+            result = await client.write_register(
+                address=address, value=int(value), device_id=device_id
+            )
+            if result.isError():
+                raise HeidelbergEnergyControlWriteError(
+                    f"Failed to write command {key} (register {address})"
+                )
+            return True
+        except (ModbusException, OSError) as err:
+            _LOGGER.error(
+                "Error on writing command %s (reg %s): %s", key, address, err
+            )
+            raise HeidelbergEnergyControlWriteError(
+                f"Failed to write command {key} (register {address}): {err}"
+            ) from err

--- a/custom_components/heidelberg_energy_control/switch.py
+++ b/custom_components/heidelberg_energy_control/switch.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HeidelbergEnergyControlConfigEntry
 from .classes.heidelberg_switch import HeidelbergSwitch
 from .classes.heidelberg_switch_virtual import HeidelbergSwitchVirtual
-from .const import COMMAND_REMOTE_LOCK, VIRTUAL_ENABLE
-from .core.capabilities import Capability, CoreCapability
+from .const import COMMAND_REMOTE_LOCK, COMMAND_STANDBY, VIRTUAL_ENABLE
+from .core.capabilities import Capability, CoreCapability, StandbyCapability
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -36,6 +36,15 @@ SWITCH_TYPES: tuple[HeidelbergSwitchEntityDescription, ...] = (
         on_value=0,
         off_value=1,
         capability=CoreCapability,
+    ),
+    HeidelbergSwitchEntityDescription(
+        key=COMMAND_STANDBY,
+        translation_key=COMMAND_STANDBY,
+        icon="mdi:sleep",
+        entity_category=EntityCategory.CONFIG,
+        on_value=0,
+        off_value=4,
+        capability=StandbyCapability,
     ),
     HeidelbergSwitchEntityDescription(
         key=VIRTUAL_ENABLE,

--- a/custom_components/heidelberg_energy_control/translations/de.json
+++ b/custom_components/heidelberg_energy_control/translations/de.json
@@ -124,6 +124,9 @@
       "remote_lock_command": {
         "name": "Remote Lock"
       },
+      "standby_function_control": {
+        "name": "Standby-Modus"
+      },
       "virtual_enable": {
         "name": "Ladefreigabe"
       }

--- a/custom_components/heidelberg_energy_control/translations/en.json
+++ b/custom_components/heidelberg_energy_control/translations/en.json
@@ -124,6 +124,9 @@
       "remote_lock_command": {
         "name": "Remote Lock"
       },
+      "standby_function_control": {
+        "name": "Standby Mode"
+      },
       "virtual_enable": {
         "name": "Charge Enable"
       }

--- a/tests/test_standby_capability.py
+++ b/tests/test_standby_capability.py
@@ -1,0 +1,141 @@
+"""Tests for StandbyCapability (register 258, v1.0.8+).
+
+Standby control lives on holding register 258:
+  - value 0  = standby function ENABLED (device sleeps after 10 min idle)
+  - value 4  = standby function DISABLED (device always awake)
+
+The switch entity is "on" when standby is enabled, matching the
+literal register semantics (Matthias's original PR #31 design).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.heidelberg_energy_control.const import (
+    COMMAND_REMOTE_LOCK,
+    COMMAND_STANDBY,
+)
+from custom_components.heidelberg_energy_control.core.api import (
+    HeidelbergEnergyControlAPI,
+)
+from custom_components.heidelberg_energy_control.core.capabilities.standby import (
+    REG_COMMAND_STANDBY,
+    StandbyCapability,
+)
+from custom_components.heidelberg_energy_control.core.exceptions import (
+    HeidelbergEnergyControlWriteError,
+)
+from custom_components.heidelberg_energy_control.core.registers import (
+    RegisterDefinition,
+    RegisterType,
+)
+
+
+# ---------- version gate & polled definitions ----------
+
+
+def test_standby_gated_at_1_0_8():
+    assert StandbyCapability.min_layout_version == "1.0.8"
+
+
+def test_standby_declares_holding_register_258():
+    assert StandbyCapability.polled_definitions == (
+        RegisterDefinition(REG_COMMAND_STANDBY, 1, RegisterType.HOLDING),
+    )
+
+
+# ---------- decode_polled: dict-based ----------
+
+
+def test_decode_polled_maps_zero_to_enabled():
+    cap = StandbyCapability()
+    result = cap.decode_polled({REG_COMMAND_STANDBY: 0})
+    assert result == {COMMAND_STANDBY: True}
+
+
+def test_decode_polled_maps_four_to_disabled():
+    cap = StandbyCapability()
+    result = cap.decode_polled({REG_COMMAND_STANDBY: 4})
+    assert result == {COMMAND_STANDBY: False}
+
+
+def test_decode_polled_ignores_unrelated_addresses():
+    cap = StandbyCapability()
+    result = cap.decode_polled({REG_COMMAND_STANDBY: 0, 999: 42})
+    assert result == {COMMAND_STANDBY: True}
+
+
+# ---------- write dispatch: capability-level ----------
+
+
+def test_supports_write_matches_only_standby_key():
+    cap = StandbyCapability()
+    assert cap.supports_write(COMMAND_STANDBY) is True
+    assert cap.supports_write(COMMAND_REMOTE_LOCK) is False
+    assert cap.supports_write("nope") is False
+
+
+async def test_async_write_forwards_value_to_register_258():
+    cap = StandbyCapability()
+    client = MagicMock()
+    write_result = MagicMock()
+    write_result.isError = MagicMock(return_value=False)
+    client.write_register = AsyncMock(return_value=write_result)
+
+    ok = await cap.async_write(client, device_id=1, key=COMMAND_STANDBY, value=4)
+
+    assert ok is True
+    client.write_register.assert_awaited_once_with(
+        address=REG_COMMAND_STANDBY, value=4, device_id=1
+    )
+
+
+async def test_async_write_raises_on_modbus_error_response():
+    cap = StandbyCapability()
+    client = MagicMock()
+    write_result = MagicMock()
+    write_result.isError = MagicMock(return_value=True)
+    client.write_register = AsyncMock(return_value=write_result)
+
+    with pytest.raises(HeidelbergEnergyControlWriteError):
+        await cap.async_write(client, device_id=1, key=COMMAND_STANDBY, value=0)
+
+
+# ---------- end-to-end: dispatch via api.async_write_command ----------
+
+
+def _api_with_standby_loaded() -> tuple[HeidelbergEnergyControlAPI, MagicMock]:
+    """Build an API instance with Core + Standby capabilities pre-loaded."""
+    api = HeidelbergEnergyControlAPI(host="x", port=502, device_id=1)
+    api._capabilities.append(StandbyCapability())
+
+    client = MagicMock()
+    client.connected = True
+
+    async def _noop_connect() -> bool:
+        return True
+
+    client.connect = AsyncMock(side_effect=_noop_connect)
+    client.close = MagicMock()
+
+    write_result = MagicMock()
+    write_result.isError = MagicMock(return_value=False)
+    client.write_register = AsyncMock(return_value=write_result)
+
+    api._client = client
+    return api, client
+
+
+async def test_api_async_write_command_dispatches_standby_to_register_258():
+    """COMMAND_STANDBY on the api routes to StandbyCapability → register 258."""
+    api, client = _api_with_standby_loaded()
+
+    ok = await api.async_write_command(COMMAND_STANDBY, 4)
+
+    assert ok is True
+    client.write_register.assert_awaited_once_with(
+        address=REG_COMMAND_STANDBY, value=4, device_id=1
+    )


### PR DESCRIPTION
Introduces StandbyCapability owning holding register 258. Value 0 enables the wallbox's built-in standby (default, device sleeps after 10 min idle), value 4 disables it so the wallbox stays awake and remains reachable over Modbus indefinitely.

The switch reads "on" when the standby function is enabled (register value 0), matching the literal register semantics. Gated to firmware layout version >= 1.0.8; entity is not created below that.

Supersedes #31 by using the capability contract (private register, symbolic command-key writes) instead of leaking the address through const.py and adding an ad-hoc read to api.py.

## Description
  - New StandbyCapability module owning register 258 privately.
  - Gated by min_layout_version="1.0.8" — entity is only created on
  supported firmware.
  - Registered in the CAPABILITIES tuple, so version-gating and load
  happen automatically via the shared block-read path.
  - Adds COMMAND_STANDBY key to const.py; the register address stays
  inside the capability.
  - Switch is "on" when standby is enabled (register value 0), matching
  the literal register semantics from Matthias's original PR.
  - DE/EN translations, README bullet, tests.

Tested against my Steca Charger with v1.0.8 support

### Checklist
- [x] The PR title follows the format: `type: description` (feat, fix, perf, docs, chore, ci)
- [x] I have tested these changes in my Home Assistant environment
- [x] I have linked a related Issue if one exists

