### PR TITLE
ci: update permissions to include statuses for PR validation

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      statuses: write
     steps:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.0


### PR DESCRIPTION
## Description
add `statuses: write` permission to workflow.

### Checklist
- [x] The PR title follows the format: `type: description` (feat, fix, perf, docs, chore, ci)
- [x] I have tested these changes in my Home Assistant environment
- [x] I have linked a related Issue if one exists

**Issue:** closes #<!-- Link a related Issue: #ID -->