### PR TITLE
feat: apply multiplier symmetrically on read and write

### DIFF
--- a/custom_components/heidelberg_energy_control/classes/heidelberg_number.py
+++ b/custom_components/heidelberg_energy_control/classes/heidelberg_number.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.number import NumberEntity
 
 from ..classes.heidelberg_entity_base import HeidelbergEntityBase
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class HeidelbergNumber(HeidelbergEntityBase, NumberEntity):
@@ -16,7 +12,9 @@ class HeidelbergNumber(HeidelbergEntityBase, NumberEntity):
 
     Coordinator data holds raw wire values (e.g. deci-amps, milliseconds).
     The entity's `multiplier` converts between display units and the wire
-    format symmetrically: divide on read, multiply on write.
+    format symmetrically: divide on read, multiply on write. A `None`
+    multiplier means the wire value is already the display value on both
+    sides.
     """
 
     @property
@@ -31,15 +29,10 @@ class HeidelbergNumber(HeidelbergEntityBase, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Write value to hardware and update coordinator data."""
-
         if self.entity_description.multiplier is None:
-            _LOGGER.error(
-                "Cannot write %s: Missing multiplier in description",
-                self.entity_description.key,
-            )
-            return
-
-        modbus_value = int(value * self.entity_description.multiplier)
+            modbus_value = int(value)
+        else:
+            modbus_value = int(value * self.entity_description.multiplier)
 
         success = await self.coordinator.api.async_write_command(
             self.entity_description.key, modbus_value

--- a/custom_components/heidelberg_energy_control/classes/heidelberg_number.py
+++ b/custom_components/heidelberg_energy_control/classes/heidelberg_number.py
@@ -12,12 +12,22 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class HeidelbergNumber(HeidelbergEntityBase, NumberEntity):
-    """Base class for Heidelberg hardware number entities (Modbus)."""
+    """Base class for Heidelberg hardware number entities (Modbus).
+
+    Coordinator data holds raw wire values (e.g. deci-amps, milliseconds).
+    The entity's `multiplier` converts between display units and the wire
+    format symmetrically: divide on read, multiply on write.
+    """
 
     @property
     def native_value(self) -> float | None:
-        """Return the value from coordinator data."""
-        return self.coordinator.data.get(self.entity_description.key)
+        """Return the display value, converted from the raw coordinator data."""
+        raw = self.coordinator.data.get(self.entity_description.key)
+        if raw is None:
+            return None
+        if self.entity_description.multiplier is None:
+            return raw
+        return raw / self.entity_description.multiplier
 
     async def async_set_native_value(self, value: float) -> None:
         """Write value to hardware and update coordinator data."""
@@ -36,5 +46,5 @@ class HeidelbergNumber(HeidelbergEntityBase, NumberEntity):
         )
 
         if success:
-            self.coordinator.data[self.entity_description.key] = value
+            self.coordinator.data[self.entity_description.key] = modbus_value
             self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/custom_components/heidelberg_energy_control/classes/heidelberg_sensor.py
+++ b/custom_components/heidelberg_energy_control/classes/heidelberg_sensor.py
@@ -7,22 +7,21 @@ from homeassistant.components.sensor import SensorEntity
 from .heidelberg_entity_base import HeidelbergEntityBase
 
 class HeidelbergSensor(HeidelbergEntityBase, SensorEntity):
-    """Base class for standard Heidelberg sensors."""
+    """Base class for standard Heidelberg sensors.
+
+    Coordinator data holds raw wire values (e.g. deci-amps, milliseconds).
+    The entity's `multiplier` converts to display units on read. A `None`
+    multiplier means the wire value is already the display value.
+    """
 
     @property
     def native_value(self) -> Any:
-        """Return the display value from coordinator data.
-
-        If the description carries a `multiplier`, the sensor mirrors the
-        number-entity contract: capability data is raw wire form, sensor
-        divides on read.
-        """
+        """Return the display value, converted from the raw coordinator data."""
         if not self.coordinator.data:
             return None
         raw = self.coordinator.data.get(self.entity_description.key)
         if raw is None:
             return None
-        multiplier = getattr(self.entity_description, "multiplier", None)
-        if multiplier is None:
+        if self.entity_description.multiplier is None:
             return raw
-        return raw / multiplier
+        return raw / self.entity_description.multiplier

--- a/custom_components/heidelberg_energy_control/classes/heidelberg_sensor.py
+++ b/custom_components/heidelberg_energy_control/classes/heidelberg_sensor.py
@@ -11,7 +11,18 @@ class HeidelbergSensor(HeidelbergEntityBase, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        """Return value from coordinator."""
+        """Return the display value from coordinator data.
+
+        If the description carries a `multiplier`, the sensor mirrors the
+        number-entity contract: capability data is raw wire form, sensor
+        divides on read.
+        """
         if not self.coordinator.data:
             return None
-        return self.coordinator.data.get(self.entity_description.key)
+        raw = self.coordinator.data.get(self.entity_description.key)
+        if raw is None:
+            return None
+        multiplier = getattr(self.entity_description, "multiplier", None)
+        if multiplier is None:
+            return raw
+        return raw / multiplier

--- a/custom_components/heidelberg_energy_control/coordinator.py
+++ b/custom_components/heidelberg_energy_control/coordinator.py
@@ -105,8 +105,7 @@ class HeidelbergEnergyControlCoordinator(DataUpdateCoordinator):
                 return data
 
             # --- Virtual Logic (only for V1.0.7+) ---
-            # COMMAND_TARGET_CURRENT is deci-amps in coordinator data; convert
-            # to amps for the virtual-slider comparison and storage.
+            # Raw value is deci-amps; convert to amps for the virtual entities.
             hw_current = float(data.get(COMMAND_TARGET_CURRENT, 0)) / 10.0
 
             # Initial sync on startup: Read wallbox current state
@@ -168,7 +167,6 @@ class HeidelbergEnergyControlCoordinator(DataUpdateCoordinator):
                 COMMAND_TARGET_CURRENT, modbus_value
             )
 
-            # Coordinator data holds the raw wire value (deci-amps).
             self.data[COMMAND_TARGET_CURRENT] = modbus_value
             self.async_update_listeners()
 

--- a/custom_components/heidelberg_energy_control/coordinator.py
+++ b/custom_components/heidelberg_energy_control/coordinator.py
@@ -105,7 +105,9 @@ class HeidelbergEnergyControlCoordinator(DataUpdateCoordinator):
                 return data
 
             # --- Virtual Logic (only for V1.0.7+) ---
-            hw_current = float(data.get(COMMAND_TARGET_CURRENT, 0.0))
+            # COMMAND_TARGET_CURRENT is deci-amps in coordinator data; convert
+            # to amps for the virtual-slider comparison and storage.
+            hw_current = float(data.get(COMMAND_TARGET_CURRENT, 0)) / 10.0
 
             # Initial sync on startup: Read wallbox current state
             if not self._initial_fetch_done:
@@ -166,8 +168,8 @@ class HeidelbergEnergyControlCoordinator(DataUpdateCoordinator):
                 COMMAND_TARGET_CURRENT, modbus_value
             )
 
-            # Update local state for immediate UI feedback
-            self.data[COMMAND_TARGET_CURRENT] = value
+            # Coordinator data holds the raw wire value (deci-amps).
+            self.data[COMMAND_TARGET_CURRENT] = modbus_value
             self.async_update_listeners()
 
         except (
@@ -234,12 +236,17 @@ class HeidelbergEnergyControlCoordinator(DataUpdateCoordinator):
         successful transaction within the watchdog window. A poll interval
         near the timeout gives no room for a single missed poll; warn the
         user once when scan_interval * 1.5 > timeout so they can retune.
+
+        Watchdog timeout is stored in the coordinator data as raw ms (wire
+        format); convert to seconds here for a like-for-like comparison
+        against the scan interval.
         """
         if self._watchdog_warning_logged:
             return
-        timeout_seconds = data.get(COMMAND_WATCHDOG_TIMEOUT)
-        if not timeout_seconds:  # None or 0 (watchdog disabled)
+        timeout_ms = data.get(COMMAND_WATCHDOG_TIMEOUT)
+        if not timeout_ms:  # None or 0 (watchdog disabled)
             return
+        timeout_seconds = timeout_ms / 1000.0
         headroom_seconds = self._scan_interval_seconds * 1.5
         if headroom_seconds > timeout_seconds:
             _LOGGER.warning(

--- a/custom_components/heidelberg_energy_control/core/capabilities/core.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/core.py
@@ -163,7 +163,9 @@ class CoreCapability(Capability):
             DATA_IS_PLUGGED: state_reg >= 4,
             DATA_IS_CHARGING: power_reg > 0,
             COMMAND_REMOTE_LOCK: registers[REG_COMMAND_REMOTE_LOCK] == 0,
-            COMMAND_TARGET_CURRENT: registers[REG_COMMAND_TARGET_CURRENT] / 10.0,
+            # Bidirectional value: capability returns raw deci-amps, the number
+            # entity applies its multiplier symmetrically on read and write.
+            COMMAND_TARGET_CURRENT: registers[REG_COMMAND_TARGET_CURRENT],
         }
 
     def supports_write(self, key: str) -> bool:

--- a/custom_components/heidelberg_energy_control/core/capabilities/core.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/core.py
@@ -163,8 +163,6 @@ class CoreCapability(Capability):
             DATA_IS_PLUGGED: state_reg >= 4,
             DATA_IS_CHARGING: power_reg > 0,
             COMMAND_REMOTE_LOCK: registers[REG_COMMAND_REMOTE_LOCK] == 0,
-            # Bidirectional value: capability returns raw deci-amps, the number
-            # entity applies its multiplier symmetrically on read and write.
             COMMAND_TARGET_CURRENT: registers[REG_COMMAND_TARGET_CURRENT],
         }
 

--- a/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
@@ -7,11 +7,11 @@ and overrides the target current (register 261) with the FailSafe
 Current (register 262, deci-amps; 0 or 60..160). When HA resumes
 polling, the target-current register takes over again.
 
-Wire format is ms and deci-amps; the capability exposes the values in
-their natural units (seconds, amps) on the coordinator side so the
-number entities can present them without further conversion. The
-entity descriptions carry the multipliers that convert back to the
-wire format on write.
+Capability passes the raw wire values (ms, deci-amps) through to the
+coordinator data dict. The number entities own the display conversion:
+their `multiplier` is applied symmetrically — divide on read, multiply
+on write — so callers of `self.coordinator.data[key]` see the same
+wire-format integer that goes back over Modbus.
 """
 
 from __future__ import annotations
@@ -49,9 +49,11 @@ class WatchdogCapability(Capability):
     )
 
     def decode_polled(self, registers: dict[int, int]) -> dict[str, Any]:
+        # Both are bidirectional; the number entities apply their multipliers
+        # symmetrically on read and write. Capability returns raw wire values.
         return {
-            COMMAND_WATCHDOG_TIMEOUT: registers[REG_WATCHDOG_TIMEOUT] / 1000.0,
-            COMMAND_FAILSAFE_CURRENT: registers[REG_FAILSAFE_CURRENT] / 10.0,
+            COMMAND_WATCHDOG_TIMEOUT: registers[REG_WATCHDOG_TIMEOUT],
+            COMMAND_FAILSAFE_CURRENT: registers[REG_FAILSAFE_CURRENT],
         }
 
     def supports_write(self, key: str) -> bool:

--- a/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
@@ -49,8 +49,6 @@ class WatchdogCapability(Capability):
     )
 
     def decode_polled(self, registers: dict[int, int]) -> dict[str, Any]:
-        # Both are bidirectional; the number entities apply their multipliers
-        # symmetrically on read and write. Capability returns raw wire values.
         return {
             COMMAND_WATCHDOG_TIMEOUT: registers[REG_WATCHDOG_TIMEOUT],
             COMMAND_FAILSAFE_CURRENT: registers[REG_FAILSAFE_CURRENT],

--- a/custom_components/heidelberg_energy_control/number.py
+++ b/custom_components/heidelberg_energy_control/number.py
@@ -32,7 +32,7 @@ class HeidelbergNumberEntityDescription(NumberEntityDescription):
 
     capability: type[Capability]
 
-    # Optional: virtual numbers don't need it
+    # Optional: display-unit divisor for values on raw wire form.
     multiplier: float | None = None
 
 

--- a/custom_components/heidelberg_energy_control/sensor.py
+++ b/custom_components/heidelberg_energy_control/sensor.py
@@ -58,9 +58,7 @@ class HeidelbergSensorEntityDescription(SensorEntityDescription):
 
     capability: type[Capability]
 
-    # For bidirectional wire values that appear as both a number entity and a
-    # diagnostic sensor: the capability stores raw wire form, both entities
-    # divide by multiplier on read.
+    # Optional: display-unit divisor for values on raw wire form.
     multiplier: float | None = None
 
 

--- a/custom_components/heidelberg_energy_control/sensor.py
+++ b/custom_components/heidelberg_energy_control/sensor.py
@@ -58,6 +58,11 @@ class HeidelbergSensorEntityDescription(SensorEntityDescription):
 
     capability: type[Capability]
 
+    # For bidirectional wire values that appear as both a number entity and a
+    # diagnostic sensor: the capability stores raw wire form, both entities
+    # divide by multiplier on read.
+    multiplier: float | None = None
+
 
 SENSOR_TYPES: tuple[HeidelbergSensorEntityDescription, ...] = (
     HeidelbergSensorEntityDescription(
@@ -206,6 +211,7 @@ SENSOR_TYPES: tuple[HeidelbergSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=1,
         capability=CoreCapability,
+        multiplier=10,
     ),
     HeidelbergSensorEntityDescription(
         key=DATA_HW_MAX_CURR,

--- a/tests/test_api_decoding.py
+++ b/tests/test_api_decoding.py
@@ -80,7 +80,8 @@ VARIANT_V1_0_7 = pytest.param(
         DATA_IS_PLUGGED: True,
         DATA_IS_CHARGING: True,
         COMMAND_REMOTE_LOCK: False,
-        COMMAND_TARGET_CURRENT: 16.0,
+        # Deci-amps at the wire level; number entity divides by 10 for display.
+        COMMAND_TARGET_CURRENT: 160,
     },
     id="v1.0.7-synthetic",
 )
@@ -112,7 +113,7 @@ VARIANT_V2_0_4 = pytest.param(
         DATA_IS_PLUGGED: True,
         DATA_IS_CHARGING: True,  # power_reg > 0 → True even at 1 W (sensor noise)
         COMMAND_REMOTE_LOCK: False,
-        COMMAND_TARGET_CURRENT: 6.0,
+        COMMAND_TARGET_CURRENT: 60,
     },
     id="v2.0.4-real",
 )
@@ -181,11 +182,15 @@ async def test_polled_data_decoding_full_dict(fixture_name, expected_static, exp
 
 
 async def test_polled_data_currents_decoded_as_deciamps():
-    """Wire format stores currents in 0.1 A units; decoded values divide by 10."""
+    """L1 phase current is a sensor-only value → capability divides for display (amps).
+
+    COMMAND_TARGET_CURRENT is bidirectional (has a number entity) → capability
+    leaves it as raw deci-amps; the entity applies its multiplier symmetrically.
+    """
     api = _make_api("wallbox_v1_0_7")
     result = await api.async_get_data()
     assert result[DATA_CURRENT_L1] == 16.0
-    assert result[COMMAND_TARGET_CURRENT] == 16.0
+    assert result[COMMAND_TARGET_CURRENT] == 160
 
 
 async def test_polled_data_charging_state_mapped_to_letter():

--- a/tests/test_capability_decode.py
+++ b/tests/test_capability_decode.py
@@ -121,7 +121,8 @@ def test_decode_polled_returns_full_output_from_dict():
     assert result[DATA_CURRENT_L1] == 16.0
     assert result[DATA_TOTAL_ENERGY] == 12345.6
     assert result[DATA_IS_CHARGING] is True
-    assert result[COMMAND_TARGET_CURRENT] == 16.0
+    # Bidirectional value: capability returns raw deci-amps (160 = 16.0 A).
+    assert result[COMMAND_TARGET_CURRENT] == 160
     assert result[COMMAND_REMOTE_LOCK] is False
 
 

--- a/tests/test_coordinator_virtual.py
+++ b/tests/test_coordinator_virtual.py
@@ -56,9 +56,13 @@ async def test_initial_sync_hw_zero_keeps_switch_off(hass, mock_api):
 
 
 async def test_initial_sync_hw_nonzero_enables_switch_and_seeds_slider(hass, mock_api):
-    """Wallbox reports 12 A on startup → virtual switch ON, slider catches up to 12 A."""
+    """Wallbox reports 12 A on startup → virtual switch ON, slider catches up to 12 A.
+
+    Coordinator data holds COMMAND_TARGET_CURRENT as raw deci-amps (120 = 12.0 A);
+    virtual-logic path converts to amps for comparison and storage.
+    """
     coord = _make_coordinator(hass, mock_api)
-    mock_api.async_get_data.return_value = {COMMAND_TARGET_CURRENT: 12.0}
+    mock_api.async_get_data.return_value = {COMMAND_TARGET_CURRENT: 120}
 
     result = await coord._async_update_data()
 
@@ -93,7 +97,7 @@ async def test_external_hw_nonzero_with_switch_off_flips_switch_on(hass, mock_ap
     coord.target_current = 10.0
     coord._initial_fetch_done = True
 
-    mock_api.async_get_data.return_value = {COMMAND_TARGET_CURRENT: 14.0}
+    mock_api.async_get_data.return_value = {COMMAND_TARGET_CURRENT: 140}
     result = await coord._async_update_data()
 
     assert coord.logic_enabled is True

--- a/tests/test_coordinator_watchdog_warning.py
+++ b/tests/test_coordinator_watchdog_warning.py
@@ -5,8 +5,9 @@ timeout, a single missed poll will trigger the FailSafe current. The
 coordinator watches for that config mismatch on each successful update
 and logs a one-shot warning so the user can retune before it bites.
 
-The watchdog timeout is stored in seconds in the coordinator data
-(the capability divides the raw ms register value by 1000).
+The watchdog timeout is stored in the coordinator data as raw
+milliseconds (wire format); the headroom check converts to seconds
+locally for the like-for-like comparison against the scan interval.
 
 Rules:
   - Watchdog disabled (timeout = 0) or unknown → no warning.
@@ -64,7 +65,7 @@ async def test_no_warning_when_poll_headroom_is_sufficient(hass, mock_api, caplo
     coord = _make_coordinator(hass, mock_api, scan_interval=5)
     mock_api.async_get_data.return_value = {
         COMMAND_TARGET_CURRENT: 0.0,
-        COMMAND_WATCHDOG_TIMEOUT: 15.0,
+        COMMAND_WATCHDOG_TIMEOUT: 15000,
     }
 
     await coord._async_update_data()
@@ -77,7 +78,7 @@ async def test_warning_when_poll_too_slow_for_watchdog(hass, mock_api, caplog):
     coord = _make_coordinator(hass, mock_api, scan_interval=30)
     mock_api.async_get_data.return_value = {
         COMMAND_TARGET_CURRENT: 0.0,
-        COMMAND_WATCHDOG_TIMEOUT: 15.0,
+        COMMAND_WATCHDOG_TIMEOUT: 15000,
     }
 
     await coord._async_update_data()
@@ -90,7 +91,7 @@ async def test_warning_fires_only_once(hass, mock_api, caplog):
     coord = _make_coordinator(hass, mock_api, scan_interval=30)
     mock_api.async_get_data.return_value = {
         COMMAND_TARGET_CURRENT: 0.0,
-        COMMAND_WATCHDOG_TIMEOUT: 15.0,
+        COMMAND_WATCHDOG_TIMEOUT: 15000,
     }
 
     await coord._async_update_data()

--- a/tests/test_number_multiplier_symmetry.py
+++ b/tests/test_number_multiplier_symmetry.py
@@ -1,0 +1,115 @@
+"""Round-trip tests for read/write symmetry on number entities.
+
+Under the multiplier-symmetry contract:
+  - capability decode returns raw wire values (deci-amps, ms)
+  - number entity divides by multiplier on `native_value` (read)
+  - number entity multiplies by multiplier on `async_set_native_value` (write)
+  - sensor entities with a `multiplier` do the same divide-on-read
+
+The intent: what a user sees in the UI (`native_value`) is the same
+number the entity would round-trip back to hardware if they set that
+value with the slider.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.heidelberg_energy_control.classes.heidelberg_number import (
+    HeidelbergNumber,
+)
+from custom_components.heidelberg_energy_control.classes.heidelberg_sensor import (
+    HeidelbergSensor,
+)
+from custom_components.heidelberg_energy_control.const import COMMAND_TARGET_CURRENT
+
+
+def _mock_coordinator(data: dict) -> MagicMock:
+    coord = MagicMock()
+    coord.data = data
+    # Entity base __init__ builds DeviceInfo from static_data — needs all three
+    # version fields to concatenate the "v" prefix without a TypeError.
+    coord.static_data = {
+        "reg_layout_ver": "1.0.8",
+        "hw_version": "1.0.0",
+        "sw_version": "1.0.8",
+    }
+    coord.api = MagicMock()
+    coord.api.async_write_command = AsyncMock(return_value=True)
+    coord.async_set_updated_data = MagicMock()
+    return coord
+
+
+def _make_number_entity(coord, multiplier: float) -> HeidelbergNumber:
+    entry = MagicMock()
+    entry.entry_id = "test"
+    desc = MagicMock()
+    desc.key = COMMAND_TARGET_CURRENT
+    desc.multiplier = multiplier
+    return HeidelbergNumber(coord, entry, desc)
+
+
+def test_number_native_value_divides_by_multiplier():
+    """Raw deci-amps in coordinator data → amps displayed to user."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 160})
+    entity = _make_number_entity(coord, multiplier=10)
+    assert entity.native_value == 16.0
+
+
+def test_number_native_value_none_when_data_missing():
+    coord = _mock_coordinator({})
+    entity = _make_number_entity(coord, multiplier=10)
+    assert entity.native_value is None
+
+
+def test_number_native_value_passthrough_when_multiplier_is_none():
+    """A None multiplier means the wire value is already the display value."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 42})
+    entity = _make_number_entity(coord, multiplier=None)
+    assert entity.native_value == 42
+
+
+async def test_number_write_multiplies_and_stores_raw():
+    """User sets 12.0 A → API receives 120 deci-amps → data holds 120."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 0})
+    entity = _make_number_entity(coord, multiplier=10)
+
+    await entity.async_set_native_value(12.0)
+
+    coord.api.async_write_command.assert_awaited_once_with(
+        COMMAND_TARGET_CURRENT, 120
+    )
+    assert coord.data[COMMAND_TARGET_CURRENT] == 120
+
+
+async def test_number_round_trip_read_after_write():
+    """Set 8.5 A, then read: entity shows 8.5 A back."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 0})
+    entity = _make_number_entity(coord, multiplier=10)
+
+    await entity.async_set_native_value(8.5)
+
+    assert entity.native_value == 8.5
+
+
+def test_sensor_native_value_divides_by_multiplier():
+    """Diagnostic sensor mirrors the number entity's divide-on-read."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 160})
+    entry = MagicMock()
+    entry.entry_id = "test"
+    desc = MagicMock()
+    desc.key = COMMAND_TARGET_CURRENT
+    desc.multiplier = 10
+    entity = HeidelbergSensor(coord, entry, desc)
+    assert entity.native_value == 16.0
+
+
+def test_sensor_native_value_passthrough_when_multiplier_missing():
+    """Sensors without a multiplier return raw coordinator values (backwards compat)."""
+    coord = _mock_coordinator({"data_current_l1": 16.0})
+    entry = MagicMock()
+    entry.entry_id = "test"
+    desc = MagicMock(spec=[])  # spec=[] => no multiplier attr
+    desc.key = "data_current_l1"
+    entity = HeidelbergSensor(coord, entry, desc)
+    assert entity.native_value == 16.0

--- a/tests/test_number_multiplier_symmetry.py
+++ b/tests/test_number_multiplier_symmetry.py
@@ -82,6 +82,19 @@ async def test_number_write_multiplies_and_stores_raw():
     assert coord.data[COMMAND_TARGET_CURRENT] == 120
 
 
+async def test_number_write_passthrough_when_multiplier_is_none():
+    """A None multiplier means the display value is already the wire value."""
+    coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 0})
+    entity = _make_number_entity(coord, multiplier=None)
+
+    await entity.async_set_native_value(42.0)
+
+    coord.api.async_write_command.assert_awaited_once_with(
+        COMMAND_TARGET_CURRENT, 42
+    )
+    assert coord.data[COMMAND_TARGET_CURRENT] == 42
+
+
 async def test_number_round_trip_read_after_write():
     """Set 8.5 A, then read: entity shows 8.5 A back."""
     coord = _mock_coordinator({COMMAND_TARGET_CURRENT: 0})
@@ -104,12 +117,13 @@ def test_sensor_native_value_divides_by_multiplier():
     assert entity.native_value == 16.0
 
 
-def test_sensor_native_value_passthrough_when_multiplier_missing():
-    """Sensors without a multiplier return raw coordinator values (backwards compat)."""
+def test_sensor_native_value_passthrough_when_multiplier_is_none():
+    """A None multiplier means the wire value is already the display value."""
     coord = _mock_coordinator({"data_current_l1": 16.0})
     entry = MagicMock()
     entry.entry_id = "test"
-    desc = MagicMock(spec=[])  # spec=[] => no multiplier attr
+    desc = MagicMock()
     desc.key = "data_current_l1"
+    desc.multiplier = None
     entity = HeidelbergSensor(coord, entry, desc)
     assert entity.native_value == 16.0

--- a/tests/test_watchdog_capability.py
+++ b/tests/test_watchdog_capability.py
@@ -56,15 +56,15 @@ def test_watchdog_declares_both_holding_registers():
 # ---------- decode_polled ----------
 
 
-def test_decode_polled_returns_timeout_seconds_and_failsafe_amps():
-    """Timeout divides ms by 1000 for seconds; failsafe divides by 10 for amps."""
+def test_decode_polled_returns_raw_wire_values():
+    """Both are bidirectional; capability passes raw ms and deci-amps through."""
     cap = WatchdogCapability()
     result = cap.decode_polled(
         {REG_WATCHDOG_TIMEOUT: 15000, REG_FAILSAFE_CURRENT: 80}
     )
     assert result == {
-        COMMAND_WATCHDOG_TIMEOUT: 15.0,
-        COMMAND_FAILSAFE_CURRENT: 8.0,
+        COMMAND_WATCHDOG_TIMEOUT: 15000,
+        COMMAND_FAILSAFE_CURRENT: 80,
     }
 
 
@@ -74,8 +74,8 @@ def test_decode_polled_watchdog_disabled():
     result = cap.decode_polled(
         {REG_WATCHDOG_TIMEOUT: 0, REG_FAILSAFE_CURRENT: 0}
     )
-    assert result[COMMAND_WATCHDOG_TIMEOUT] == 0.0
-    assert result[COMMAND_FAILSAFE_CURRENT] == 0.0
+    assert result[COMMAND_WATCHDOG_TIMEOUT] == 0
+    assert result[COMMAND_FAILSAFE_CURRENT] == 0
 
 
 def test_decode_polled_ignores_unrelated_addresses():
@@ -84,8 +84,8 @@ def test_decode_polled_ignores_unrelated_addresses():
         {REG_WATCHDOG_TIMEOUT: 15000, REG_FAILSAFE_CURRENT: 60, 999: 42}
     )
     assert result == {
-        COMMAND_WATCHDOG_TIMEOUT: 15.0,
-        COMMAND_FAILSAFE_CURRENT: 6.0,
+        COMMAND_WATCHDOG_TIMEOUT: 15000,
+        COMMAND_FAILSAFE_CURRENT: 60,
     }
 
 


### PR DESCRIPTION
## Description

Follow-up to review feedback on #35: HeidelbergNumber multiplied by its multiplier on write but not on read, and capabilities compensated by dividing inside decode_polled. That coupled capabilities to entity display units and made the contract asymmetric.

Move display conversion onto the entity side:
  - HeidelbergNumber.native_value divides raw coordinator data by multiplier; async_set_native_value's optimistic update now stores the raw wire value.
  - HeidelbergSensor.native_value also divides by multiplier when the description carries one (for diagnostic sensors that share a key with a number entity).
  - HeidelbergSensorEntityDescription gains an optional multiplier field; default None means passthrough (backwards compat for the many sensor-only values without a wire/display split).
  - CoreCapability.decode_polled and WatchdogCapability.decode_polled stop dividing bidirectional command values (target current, watchdog timeout, failsafe current). Sensor-only conversions (currents, PCB temp, energies) stay put — no asymmetry to fix there, and adding multipliers to every sensor would be scope creep.
  - Coordinator virtual-logic path converts deci-amps → amps at the consumption site; write path already sends deci-amps.
  - Coordinator watchdog headroom check converts ms → seconds locally.

Tests updated: characterization fixtures, capability decode assertions, coordinator virtual-logic feeds. Plus tests/test_number_multiplier_symmetry.py pinning the round-trip: what the user sees is what the entity writes back.

All 73 tests pass.


### Checklist
- [x] The PR title follows the format: `type: description` (feat, fix, perf, docs, chore, ci)
- [x] I have tested these changes in my Home Assistant environment

