### PR TITLE
fix: probe optional holding registers 257/258 at setup

### DIFF
--- a/custom_components/heidelberg_energy_control/core/capabilities/standby.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/standby.py
@@ -43,6 +43,22 @@ class StandbyCapability(Capability):
         RegisterDefinition(REG_COMMAND_STANDBY, 1, RegisterType.HOLDING),
     )
 
+    async def async_probe(self, client: Any, device_id: int) -> bool:
+        """Probe register 258 to confirm the standby block is present.
+
+        Layout version alone is not enough: the Amperfied connect-series
+        reports a layout >= 1.0.8 but does not expose register 258.
+        Reading the register in isolation avoids the batched-read failure
+        that would otherwise poison the 257..262 holding block.
+        """
+        try:
+            result = await client.read_holding_registers(
+                address=REG_COMMAND_STANDBY, count=1, device_id=device_id
+            )
+        except (ModbusException, OSError):
+            return False
+        return not result.isError()
+
     def decode_polled(self, registers: dict[int, int]) -> dict[str, Any]:
         # Switch is "on" when the standby function is enabled (register = 0).
         return {COMMAND_STANDBY: registers[REG_COMMAND_STANDBY] == _STANDBY_ENABLED}

--- a/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
+++ b/custom_components/heidelberg_energy_control/core/capabilities/watchdog.py
@@ -48,6 +48,22 @@ class WatchdogCapability(Capability):
         RegisterDefinition(REG_FAILSAFE_CURRENT, 1, RegisterType.HOLDING),
     )
 
+    async def async_probe(self, client: Any, device_id: int) -> bool:
+        """Probe register 257 to confirm the watchdog block is present.
+
+        Layout version alone is not enough: the Amperfied connect-series
+        reports a layout >= 1.0.8 but does not expose registers 257/258.
+        Reading the register in isolation avoids the batched-read failure
+        that would otherwise poison the whole 257..262 holding block.
+        """
+        try:
+            result = await client.read_holding_registers(
+                address=REG_WATCHDOG_TIMEOUT, count=1, device_id=device_id
+            )
+        except (ModbusException, OSError):
+            return False
+        return not result.isError()
+
     def decode_polled(self, registers: dict[int, int]) -> dict[str, Any]:
         return {
             COMMAND_WATCHDOG_TIMEOUT: registers[REG_WATCHDOG_TIMEOUT],

--- a/tests/test_optional_capability_probe.py
+++ b/tests/test_optional_capability_probe.py
@@ -1,0 +1,230 @@
+"""Regression tests for probing optional holding registers at setup.
+
+Issue #16 (upstream): the Amperfied connect-series reports layout
+version >= 1.0.8 but does not expose holding registers 257 (watchdog
+timeout) or 258 (standby control). Previously both capabilities loaded
+on any 1.0.8+ device, and the API's block-read coalescing merged the
+per-poll reads of 257 + 258 + 259 into a single Modbus transaction.
+Register 257 being absent then failed the whole batch atomically,
+producing "Failed to read 3 holding register(s) at 257" every poll.
+
+The fix: WatchdogCapability and StandbyCapability implement
+``async_probe`` — a single-register read at setup that decides
+whether the capability actually loads. On connect-series hardware
+the probe fails, the capability is skipped, and its polled_definitions
+never enter the coalescing pool.
+
+These tests pin that behavior:
+  1. Probe returns True when the register read succeeds
+  2. Probe returns False on isError() (illegal address response)
+  3. Probe returns False on ModbusException
+  4. Probe returns False on OSError
+  5. End-to-end: async_get_static_data skips capabilities whose probe
+     returned False, so their registers are never read during polling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from pymodbus.exceptions import ModbusException
+
+from custom_components.heidelberg_energy_control.core.api import (
+    HeidelbergEnergyControlAPI,
+)
+from custom_components.heidelberg_energy_control.core.capabilities.standby import (
+    REG_COMMAND_STANDBY,
+    StandbyCapability,
+)
+from custom_components.heidelberg_energy_control.core.capabilities.watchdog import (
+    REG_WATCHDOG_TIMEOUT,
+    WatchdogCapability,
+)
+
+
+# ---------- probe: watchdog ----------
+
+
+async def test_watchdog_probe_true_when_register_readable():
+    cap = WatchdogCapability()
+    client = MagicMock()
+    ok = MagicMock()
+    ok.isError = MagicMock(return_value=False)
+    client.read_holding_registers = AsyncMock(return_value=ok)
+
+    assert await cap.async_probe(client, device_id=1) is True
+    client.read_holding_registers.assert_awaited_once_with(
+        address=REG_WATCHDOG_TIMEOUT, count=1, device_id=1
+    )
+
+
+async def test_watchdog_probe_false_on_illegal_address_response():
+    """pymodbus returns a response object with isError() True — not a raised exception."""
+    cap = WatchdogCapability()
+    client = MagicMock()
+    err = MagicMock()
+    err.isError = MagicMock(return_value=True)
+    client.read_holding_registers = AsyncMock(return_value=err)
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+async def test_watchdog_probe_false_on_modbus_exception():
+    cap = WatchdogCapability()
+    client = MagicMock()
+    client.read_holding_registers = AsyncMock(side_effect=ModbusException("boom"))
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+async def test_watchdog_probe_false_on_oserror():
+    cap = WatchdogCapability()
+    client = MagicMock()
+    client.read_holding_registers = AsyncMock(side_effect=OSError("network down"))
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+# ---------- probe: standby ----------
+
+
+async def test_standby_probe_true_when_register_readable():
+    cap = StandbyCapability()
+    client = MagicMock()
+    ok = MagicMock()
+    ok.isError = MagicMock(return_value=False)
+    client.read_holding_registers = AsyncMock(return_value=ok)
+
+    assert await cap.async_probe(client, device_id=1) is True
+    client.read_holding_registers.assert_awaited_once_with(
+        address=REG_COMMAND_STANDBY, count=1, device_id=1
+    )
+
+
+async def test_standby_probe_false_on_illegal_address_response():
+    cap = StandbyCapability()
+    client = MagicMock()
+    err = MagicMock()
+    err.isError = MagicMock(return_value=True)
+    client.read_holding_registers = AsyncMock(return_value=err)
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+async def test_standby_probe_false_on_modbus_exception():
+    cap = StandbyCapability()
+    client = MagicMock()
+    client.read_holding_registers = AsyncMock(side_effect=ModbusException("boom"))
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+async def test_standby_probe_false_on_oserror():
+    cap = StandbyCapability()
+    client = MagicMock()
+    client.read_holding_registers = AsyncMock(side_effect=OSError("network down"))
+
+    assert await cap.async_probe(client, device_id=1) is False
+
+
+# ---------- end-to-end: connect-series scenario ----------
+
+
+def _connect_series_client() -> MagicMock:
+    """Mock a connect-series wallbox: layout 2.0.4, no 257/258, has 259 and 261.
+
+    Serves the core-capability static reads (regs 4, 100/101, 200, 203),
+    then responds with isError()=True to any read of holding 257 or 258.
+    All other holding reads succeed with dummy data.
+    """
+    client = MagicMock()
+    client.connected = False
+
+    async def _connect() -> bool:
+        client.connected = True
+        return True
+
+    client.connect = AsyncMock(side_effect=_connect)
+    client.close = MagicMock()
+
+    def _make_response(registers, is_error=False):
+        rr = MagicMock()
+        rr.isError = MagicMock(return_value=is_error)
+        rr.registers = registers if registers else []
+        return rr
+
+    input_reads = {
+        (4, 1): [0x204],       # layout 2.0.4 — passes 1.0.8 gate for both caps
+        (100, 2): [16, 6],
+        (200, 1): [3],
+        (203, 1): [3],
+        (5, 14): [7, 0, 0, 0, 362, 237, 1, 1, 1, 1, 0, 0, 0, 3615],
+    }
+
+    async def _read_input(address, count, device_id):
+        return _make_response(input_reads.get((address, count), []))
+
+    async def _read_holding(address, count, device_id):
+        # Register 257 (watchdog) and 258 (standby) don't exist on connect-series
+        # — either as single-register probes or as part of any coalesced batch
+        # that includes them. Register 259 (remote lock) does exist.
+        if address <= 258 < address + count or address == 257:
+            return _make_response(None, is_error=True)
+        if address == 259 and count == 1:
+            return _make_response([1])
+        if address == 261 and count == 1:
+            return _make_response([60])
+        return _make_response(None, is_error=True)
+
+    client.read_input_registers = AsyncMock(side_effect=_read_input)
+    client.read_holding_registers = AsyncMock(side_effect=_read_holding)
+    return client
+
+
+async def test_static_setup_skips_watchdog_and_standby_on_connect_series():
+    """Regression for issue #16: setup completes and neither capability loads."""
+    api = HeidelbergEnergyControlAPI(host="x", port=502, device_id=1)
+    api._client = _connect_series_client()
+
+    static = await api.async_get_static_data()
+
+    assert static is not None
+    loaded_keys = {cap.key for cap in api.capabilities}
+    assert "watchdog" not in loaded_keys
+    assert "standby" not in loaded_keys
+    # Core capability always loads.
+    assert "core" in loaded_keys
+
+
+async def test_polled_reads_omit_unavailable_registers_on_connect_series():
+    """After setup, async_get_data must not read registers 257 or 258.
+
+    This is the direct regression check for issue #16: with the fix, the
+    coalesced holding-register read is `259..261` (or subsets), never
+    starting at 257 or including 258. Reads issued during setup (probes)
+    are expected to touch 257 and 258 by design, so we only inspect the
+    reads that happen *after* setup completes.
+    """
+    api = HeidelbergEnergyControlAPI(host="x", port=502, device_id=1)
+    client = _connect_series_client()
+    api._client = client
+
+    await api.async_get_static_data()
+    client.read_holding_registers.reset_mock()
+
+    await api.async_get_data()
+
+    assert client.read_holding_registers.await_count > 0, (
+        "sanity check: polling should still read the core capability's registers"
+    )
+    for call in client.read_holding_registers.await_args_list:
+        address = call.kwargs["address"]
+        count = call.kwargs["count"]
+        assert 257 not in range(address, address + count), (
+            f"regression: holding read {address}..{address + count - 1} "
+            f"included register 257 (should be probed absent on connect-series)"
+        )
+        assert 258 not in range(address, address + count), (
+            f"regression: holding read {address}..{address + count - 1} "
+            f"included register 258 (should be probed absent on connect-series)"
+        )


### PR DESCRIPTION
## Summary

- Adds `async_probe` to `WatchdogCapability` and `StandbyCapability`: a single-register read at setup decides whether the capability loads
- On connect-series hardware the probe fails, the capability is skipped, and its polled registers never enter the coalescing pool
- Heidelberg Energy Control units are unaffected — probe succeeds, behavior unchanged

Fixes #16
Fixes #42

## Root cause

Both capabilities gate on `min_layout_version = "1.0.8"`, but the layout version alone doesn't distinguish Heidelberg Energy Control from the Amperfied connect-series. The connect-series (Solar, Business, Home) reports layout 1.0.8+ without exposing holding registers 257 (watchdog timeout) or 258 (standby control).

The API's block-read coalescing then merges 257/258/259 into one Modbus transaction that fails atomically when 257 is absent, producing `Failed to read 3 holding register(s) at 257` on every poll. Setup can't complete first refresh, which surfaces to users as "cannot establish connection".

This mirrors the class of bug fixed for registers 200–203 back in v1.0.2-b2 and matches the "treat illegal-address as feature not present" guidance in `CLAUDE.md`.

## Test plan

- [x] New `tests/test_optional_capability_probe.py` (10 tests): probe returns True on success; False on `isError()`, `ModbusException`, `OSError` — for both capabilities
- [x] End-to-end regression: mock connect-series client, `async_get_static_data` skips both capabilities, subsequent `async_get_data` never reads 257 or 258
- [x] Full suite passes (84 tests including existing watchdog/standby capability tests)

## Post-merge validation

Needs @Pipel19 (connect.solar) and @Koblenzer (connect.business) to confirm on real hardware after a pre-release is cut. Both reported the regression on the linked issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)